### PR TITLE
Fix tiny numerical errors when switching units

### DIFF
--- a/milling.html
+++ b/milling.html
@@ -627,12 +627,13 @@
             if (g_metric)
             {
                 var value = parseFloat(g_inputsHolder.querySelector('#'+id).value);
-                g_inputsMetricHolder.querySelector('#'+id).value = parseFloat((value*metric_conversion).toFixed(7));
+                g_inputsMetricHolder.querySelector('#'+id).value = parseFloat((value*metric_conversion).toPrecision(7));
             }
             else
             {
                 var value = parseFloat(g_inputsMetricHolder.querySelector('#'+id).value);
-                g_inputsHolder.querySelector('#'+id).value = parseFloat((value/metric_conversion).toFixed(7));
+                // Higher precision for (non-clean) division helps round trip round values.
+                g_inputsHolder.querySelector('#'+id).value = parseFloat((value/metric_conversion).toPrecision(8));
             }
         }
 


### PR DESCRIPTION
Fix tiny numerical errors that happen when switching between metric and freedom units.

Example: 12mm turns into 0.4724409in and then back to 11.9999989mm. This happens due to rounding to a fixed number of digits, which for different units with large conversion factors (like 1in = 25.4mm) results in large loss of precision that almost guarantees small numerical errors show up.